### PR TITLE
change avaiable postgresql15 the default aws version

### DIFF
--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -51,7 +51,7 @@ export interface RDSProps {
     | "postgresql13.12"
     | "postgresql13.9"
     | "postgresql14.10"
-    | "postgresql15.5"
+    | "postgresql15.12"
     | "postgresql16.1";
 
   /**
@@ -459,9 +459,9 @@ export class RDS extends Construct implements SSTConstruct {
       return DatabaseClusterEngine.auroraPostgres({
         version: AuroraPostgresEngineVersion.VER_14_10,
       });
-    } else if (engine === "postgresql15.5") {
+    } else if (engine === "postgresql15.12") {
       return DatabaseClusterEngine.auroraPostgres({
-        version: AuroraPostgresEngineVersion.VER_15_5,
+        version: AuroraPostgresEngineVersion.VER_15_12,
       });
     } else if (engine === "postgresql16.1") {
       return DatabaseClusterEngine.auroraPostgres({

--- a/packages/sst/src/constructs/RDSv2.ts
+++ b/packages/sst/src/constructs/RDSv2.ts
@@ -50,7 +50,7 @@ export interface RDSv2Props {
     | 'postgresql13.12'
     | 'postgresql13.9'
     | 'postgresql14.10'
-    | 'postgresql15.5'
+    | 'postgresql15.12'
     | 'postgresql16.1';
   defaultDatabaseName: string;
   scaling?: {
@@ -218,7 +218,7 @@ export class RDSv2 extends Construct implements SSTConstruct {
       'postgresql13.12': AuroraPostgresEngineVersion.VER_13_12,
       'postgresql13.9': AuroraPostgresEngineVersion.VER_13_9,
       'postgresql14.10': AuroraPostgresEngineVersion.VER_14_10,
-      'postgresql15.5': AuroraPostgresEngineVersion.VER_15_5,
+      'postgresql15.12': AuroraPostgresEngineVersion.VER_15_12,
       'postgresql16.1': AuroraPostgresEngineVersion.VER_16_1,
     };
     return engine.includes('mysql')


### PR DESCRIPTION
Changed to 15.12, which is the default version AWS offers for major version 15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * PostgreSQL engine upgraded to version 15.12 for RDS database configurations
  * PostgreSQL 15.5 replaced with 15.12 across RDS services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->