### PR TITLE
added pg17 verison

### DIFF
--- a/packages/sst/src/constructs/RDS.ts
+++ b/packages/sst/src/constructs/RDS.ts
@@ -52,7 +52,8 @@ export interface RDSProps {
     | "postgresql13.9"
     | "postgresql14.10"
     | "postgresql15.12"
-    | "postgresql16.1";
+    | "postgresql16.1"
+    | "postgresql17.4"
 
   /**
    * Name of a database which is automatically created inside the cluster.
@@ -466,6 +467,10 @@ export class RDS extends Construct implements SSTConstruct {
     } else if (engine === "postgresql16.1") {
       return DatabaseClusterEngine.auroraPostgres({
         version: AuroraPostgresEngineVersion.VER_16_1,
+      });
+    } else if (engine === "postgresql17.4") {
+      return DatabaseClusterEngine.auroraPostgres({
+        version: AuroraPostgresEngineVersion.VER_17_4,
       });
     }
 

--- a/packages/sst/src/constructs/RDSv2.ts
+++ b/packages/sst/src/constructs/RDSv2.ts
@@ -51,7 +51,8 @@ export interface RDSv2Props {
     | 'postgresql13.9'
     | 'postgresql14.10'
     | 'postgresql15.12'
-    | 'postgresql16.1';
+    | 'postgresql16.1'
+    | 'postgresql17.4';
   defaultDatabaseName: string;
   scaling?: {
     minCapacity?: keyof typeof AuroraCapacityUnit | number;
@@ -220,6 +221,7 @@ export class RDSv2 extends Construct implements SSTConstruct {
       'postgresql14.10': AuroraPostgresEngineVersion.VER_14_10,
       'postgresql15.12': AuroraPostgresEngineVersion.VER_15_12,
       'postgresql16.1': AuroraPostgresEngineVersion.VER_16_1,
+      'postgresql17.4': AuroraPostgresEngineVersion.VER_17_4,
     };
     return engine.includes('mysql')
       ? DatabaseClusterEngine.auroraMysql({ version: versions[engine] })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL 17.4 as a supported database engine option for both RDS and RDSv2 deployments, providing access to the latest PostgreSQL version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->