### PR TITLE
upgrade aws-cdk-lib to 2.253.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,8 @@ _Note_: The `dist/package.json` is tracked in git and must be kept in sync with 
 
 1. Merge changes to [`main-bsh](https://github.com/Bluestone-Health/sst-v2/tree/main-bsh), where you can also rebase off the upstream if desired.
 2. Run `cd packages/sst` and then`pnpm run pack` to build the package.
-3. Create a release on the [Bluestone Health fork](https://github.com/Bluestone-Health/sst-v2/releases/new) and upload the package. Match the version number to the upstream version you're pinned to.
+3. Rename the tarball to match BSH versioning: `sst-<upstream-version>.<bsh-increment>.tgz`. For example, if you're mirroring upstream `2.49.6` and this is your x BSH release against it, rename to `sst-2.49.6.x.tgz`. Check the [releases page](https://github.com/Bluestone-Health/sst-v2/releases) for the last increment used.
+4. Create a release on the [Bluestone Health fork](https://github.com/Bluestone-Health/sst-v2/releases/new) and upload the renamed tarball.
 
 ### Docs
 

--- a/packages/sst/dist/package.json
+++ b/packages/sst/dist/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://sst.dev",
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.201.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.253.0-alpha.0",
     "@aws-cdk/cloud-assembly-schema": "44.5.0",
     "@aws-cdk/cloudformation-diff": "2.182.0",
     "@aws-cdk/cx-api": "2.253.0",

--- a/packages/sst/dist/package.json
+++ b/packages/sst/dist/package.json
@@ -58,7 +58,7 @@
     "@smithy/signature-v4": "2.0.16",
     "@trpc/server": "9.18.0",
     "adm-zip": "0.5.14",
-    "aws-cdk-lib": "2.201.0",
+    "aws-cdk-lib": "2.253.0",
     "aws-iot-device-sdk": "^2.2.13",
     "aws-sdk": "^2.1501.0",
     "builtin-modules": "3.2.0",

--- a/packages/sst/dist/package.json
+++ b/packages/sst/dist/package.json
@@ -32,7 +32,7 @@
     "@aws-cdk/aws-lambda-python-alpha": "2.201.0-alpha.0",
     "@aws-cdk/cloud-assembly-schema": "44.5.0",
     "@aws-cdk/cloudformation-diff": "2.182.0",
-    "@aws-cdk/cx-api": "2.201.0",
+    "@aws-cdk/cx-api": "2.253.0",
     "@aws-cdk/toolkit-lib": "1.1.1",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-cloudformation": "3.699.0",

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -65,7 +65,7 @@
     "@smithy/signature-v4": "2.0.16",
     "@trpc/server": "9.18.0",
     "adm-zip": "0.5.14",
-    "aws-cdk-lib": "2.201.0",
+    "aws-cdk-lib": "2.253.0",
     "aws-iot-device-sdk": "^2.2.13",
     "aws-sdk": "^2.1501.0",
     "builtin-modules": "3.2.0",

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://sst.dev",
   "dependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.201.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.253.0-alpha.0",
     "@aws-cdk/cloud-assembly-schema": "44.5.0",
     "@aws-cdk/cloudformation-diff": "2.182.0",
     "@aws-cdk/cx-api": "2.253.0",

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -39,7 +39,7 @@
     "@aws-cdk/aws-lambda-python-alpha": "2.201.0-alpha.0",
     "@aws-cdk/cloud-assembly-schema": "44.5.0",
     "@aws-cdk/cloudformation-diff": "2.182.0",
-    "@aws-cdk/cx-api": "2.201.0",
+    "@aws-cdk/cx-api": "2.253.0",
     "@aws-cdk/toolkit-lib": "1.1.1",
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-cloudformation": "3.699.0",

--- a/packages/sst/src/constructs/cdk/certificate-base.ts
+++ b/packages/sst/src/constructs/cdk/certificate-base.ts
@@ -17,6 +17,10 @@ export abstract class CertificateBase extends Resource implements ICertificate {
    */
   protected readonly region?: string;
 
+  get certificateRef() {
+    return { certificateId: this.certificateArn };
+  }
+
   public metricDaysToExpiry(props?: MetricOptions): Metric {
     return new Metric({
       period: Duration.days(1),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,8 +273,8 @@ importers:
   packages/sst:
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha':
-        specifier: 2.201.0-alpha.0
-        version: 2.201.0-alpha.0(aws-cdk-lib@2.253.0(constructs@10.3.0))(constructs@10.3.0)
+        specifier: 2.253.0-alpha.0
+        version: 2.253.0-alpha.0(aws-cdk-lib@2.253.0(constructs@10.3.0))(constructs@10.3.0)
       '@aws-cdk/cloud-assembly-schema':
         specifier: 44.5.0
         version: 44.5.0
@@ -282,8 +282,8 @@ importers:
         specifier: 2.182.0
         version: 2.182.0(@aws-sdk/client-cloudformation@3.699.0(aws-crt@1.27.1))
       '@aws-cdk/cx-api':
-        specifier: 2.201.0
-        version: 2.201.0(@aws-cdk/cloud-assembly-schema@44.5.0)
+        specifier: 2.253.0
+        version: 2.253.0(@aws-cdk/cloud-assembly-schema@44.5.0)
       '@aws-cdk/toolkit-lib':
         specifier: 1.1.1
         version: 1.1.1(@aws-cdk/cli-plugin-contract@2.181.0)(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0(aws-crt@1.27.1))(aws-crt@1.27.1))(aws-crt@1.27.1)
@@ -758,12 +758,12 @@ packages:
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.1':
     resolution: {integrity: sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==}
 
-  '@aws-cdk/aws-lambda-python-alpha@2.201.0-alpha.0':
-    resolution: {integrity: sha512-cvfHu5TaO6eDMIfbWKtx4hJyEwv1jSiOAXsHd1FKQqBuqM0geAf0wwDSpfIGTXHeJ0qcyz8XIi0mu/xuGGhY9w==}
-    engines: {node: '>= 14.15.0'}
+  '@aws-cdk/aws-lambda-python-alpha@2.253.0-alpha.0':
+    resolution: {integrity: sha512-IFzxu9gJ1kdTlh0i434jTuMrqZlWXTXwC+fpn7wQZOLgQd1g6u04kCwwZpHEtb/BOjp/g7UHdeyuGHWo48kVOA==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      aws-cdk-lib: ^2.201.0
-      constructs: ^10.0.0
+      aws-cdk-lib: ^2.253.0
+      constructs: ^10.5.0
 
   '@aws-cdk/aws-service-spec@0.1.82':
     resolution: {integrity: sha512-Vn0qMU00ozjmzxMgAluhS8V8H+/tk0Zk8VwKKf4kDJ3i1uFp15mfQM5vch8JwNs5Tn/xAOCX7jIavh1PiKfKYg==}
@@ -792,13 +792,14 @@ packages:
     peerDependencies:
       '@aws-sdk/client-cloudformation': ^3
 
-  '@aws-cdk/cx-api@2.201.0':
-    resolution: {integrity: sha512-wNr4vwbZDhj7RhDMOSuisJjvsm3VoWjETxhtXpqLAC6XgeLgiz23Bhq0nmpTzRDKeyvW59JO5eIkbJDSNDpdJA==}
-    engines: {node: '>= 14.15.0'}
+  '@aws-cdk/cx-api@2.253.0':
+    resolution: {integrity: sha512-ZBy1ZxCu8QnXYSqlMxFSYyPFE3+wHqINqXUthG5pGhfD+IjPjmSIG2BL9XozcGWciTKBs5NSZVWmGk4Zu45cVw==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      '@aws-cdk/cloud-assembly-schema': '>=44.1.0'
+      '@aws-cdk/cloud-assembly-schema': '>=53.18.0'
     bundledDependencies:
       - semver
+      - '@aws-cdk/cloud-assembly-api'
 
   '@aws-cdk/service-spec-types@0.0.145':
     resolution: {integrity: sha512-FBkR6cgkNahJDk5xj8p9/VzG16jX6bj9Fj4ecqWDvTuYzYpsmJOnuv2NU3HFyOINS2un8zxAZYKe8F85dhb8CQ==}
@@ -10962,7 +10963,7 @@ snapshots:
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.1': {}
 
-  '@aws-cdk/aws-lambda-python-alpha@2.201.0-alpha.0(aws-cdk-lib@2.253.0(constructs@10.3.0))(constructs@10.3.0)':
+  '@aws-cdk/aws-lambda-python-alpha@2.253.0-alpha.0(aws-cdk-lib@2.253.0(constructs@10.3.0))(constructs@10.3.0)':
     dependencies:
       aws-cdk-lib: 2.253.0(constructs@10.3.0)
       constructs: 10.3.0
@@ -10989,7 +10990,7 @@ snapshots:
       string-width: 4.2.3
       table: 6.9.0
 
-  '@aws-cdk/cx-api@2.201.0(@aws-cdk/cloud-assembly-schema@44.5.0)':
+  '@aws-cdk/cx-api@2.253.0(@aws-cdk/cloud-assembly-schema@44.5.0)':
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 44.5.0
 
@@ -11006,7 +11007,7 @@ snapshots:
       '@aws-cdk/cli-plugin-contract': 2.181.0
       '@aws-cdk/cloud-assembly-schema': 44.5.0
       '@aws-cdk/cloudformation-diff': 2.182.0(@aws-sdk/client-cloudformation@3.699.0(aws-crt@1.27.1))
-      '@aws-cdk/cx-api': 2.201.0(@aws-cdk/cloud-assembly-schema@44.5.0)
+      '@aws-cdk/cx-api': 2.253.0(@aws-cdk/cloud-assembly-schema@44.5.0)
       '@aws-sdk/client-appsync': 3.830.0(aws-crt@1.27.1)
       '@aws-sdk/client-cloudcontrol': 3.830.0(aws-crt@1.27.1)
       '@aws-sdk/client-cloudformation': 3.699.0(aws-crt@1.27.1)
@@ -19780,7 +19781,7 @@ snapshots:
   cdk-assets@3.3.1(@aws-sdk/client-sso-oidc@3.699.0(@aws-sdk/client-sts@3.699.0(aws-crt@1.27.1))(aws-crt@1.27.1))(aws-crt@1.27.1):
     dependencies:
       '@aws-cdk/cloud-assembly-schema': 44.5.0
-      '@aws-cdk/cx-api': 2.201.0(@aws-cdk/cloud-assembly-schema@44.5.0)
+      '@aws-cdk/cx-api': 2.253.0(@aws-cdk/cloud-assembly-schema@44.5.0)
       '@aws-sdk/client-ecr': 3.830.0(aws-crt@1.27.1)
       '@aws-sdk/client-s3': 3.699.0(aws-crt@1.27.1)
       '@aws-sdk/client-secrets-manager': 3.830.0(aws-crt@1.27.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ importers:
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha':
         specifier: 2.201.0-alpha.0
-        version: 2.201.0-alpha.0(aws-cdk-lib@2.201.0(constructs@10.3.0))(constructs@10.3.0)
+        version: 2.201.0-alpha.0(aws-cdk-lib@2.253.0(constructs@10.3.0))(constructs@10.3.0)
       '@aws-cdk/cloud-assembly-schema':
         specifier: 44.5.0
         version: 44.5.0
@@ -360,8 +360,8 @@ importers:
         specifier: 0.5.14
         version: 0.5.14
       aws-cdk-lib:
-        specifier: 2.201.0
-        version: 2.201.0(constructs@10.3.0)
+        specifier: 2.253.0
+        version: 2.253.0(constructs@10.3.0)
       aws-iot-device-sdk:
         specifier: ^2.2.13
         version: 2.2.15
@@ -752,11 +752,11 @@ packages:
     resolution: {integrity: sha512-+/Wruju2Ho99z0jI8zxMFGBkKKG97RzR/srSaColejUDrczkAjR3HjULKTVfDdIpvtvFZLyl7OMBmHKQazfeZg==}
     deprecated: This package is not used by Astro any more and is no longer maintained. In Astro 3.0 polyfills are part of a core module.
 
-  '@aws-cdk/asset-awscli-v1@2.2.237':
-    resolution: {integrity: sha512-OlXylbXI52lboFVJBFLae+WB99qWmI121x/wXQHEMj2RaVNVbWE+OAHcDk2Um1BitUQCaTf9ki57B0Fuqx0Rvw==}
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==}
 
-  '@aws-cdk/asset-node-proxy-agent-v6@2.1.0':
-    resolution: {integrity: sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==}
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.1':
+    resolution: {integrity: sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==}
 
   '@aws-cdk/aws-lambda-python-alpha@2.201.0-alpha.0':
     resolution: {integrity: sha512-cvfHu5TaO6eDMIfbWKtx4hJyEwv1jSiOAXsHd1FKQqBuqM0geAf0wwDSpfIGTXHeJ0qcyz8XIi0mu/xuGGhY9w==}
@@ -774,6 +774,13 @@ packages:
 
   '@aws-cdk/cloud-assembly-schema@44.5.0':
     resolution: {integrity: sha512-/dk9YtqF+BnBS6k4m7YWIp7Pd80m7jdjT8ED8gb3Rd9hAuAEUoJubO0M3EOlLFmknIesQNm95LYU6vt/MIQhWg==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@aws-cdk/cloud-assembly-schema@53.23.0':
+    resolution: {integrity: sha512-/8bIjpLrr34pMMt+/wQo1bNssHS8squz2aXKz3TVWDKhZg7TxZK7boMY1WQND9APUEtavopIBsrPqwC4Z3qESw==}
     engines: {node: '>= 18.0.0'}
     bundledDependencies:
       - jsonschema
@@ -4871,13 +4878,14 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.201.0:
-    resolution: {integrity: sha512-0ioqzM5dkJl02uchOfgeCY3thV3jTn9YkyZ/UF5P4Hq9iNGHQqmPu5xE/VcAV7+P72Z/zV+QLV0xkVT6iLF/bw==}
-    engines: {node: '>= 14.15.0'}
+  aws-cdk-lib@2.253.0:
+    resolution: {integrity: sha512-36nNLOz0WJDWraEzU7zlmYY8nsM+YEroBWpRZ84LZPaeEe4Ozy4RhBvdCz/jIGYtLbtiFnfk+przNW2NNRjz5Q==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      constructs: ^10.0.0
+      constructs: ^10.5.0
     bundledDependencies:
       - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
       - case
       - fs-extra
       - ignore
@@ -10950,13 +10958,13 @@ snapshots:
     dependencies:
       undici: 5.29.0
 
-  '@aws-cdk/asset-awscli-v1@2.2.237': {}
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
 
-  '@aws-cdk/asset-node-proxy-agent-v6@2.1.0': {}
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.1': {}
 
-  '@aws-cdk/aws-lambda-python-alpha@2.201.0-alpha.0(aws-cdk-lib@2.201.0(constructs@10.3.0))(constructs@10.3.0)':
+  '@aws-cdk/aws-lambda-python-alpha@2.201.0-alpha.0(aws-cdk-lib@2.253.0(constructs@10.3.0))(constructs@10.3.0)':
     dependencies:
-      aws-cdk-lib: 2.201.0(constructs@10.3.0)
+      aws-cdk-lib: 2.253.0(constructs@10.3.0)
       constructs: 10.3.0
 
   '@aws-cdk/aws-service-spec@0.1.82':
@@ -10967,6 +10975,8 @@ snapshots:
   '@aws-cdk/cli-plugin-contract@2.181.0': {}
 
   '@aws-cdk/cloud-assembly-schema@44.5.0': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.23.0': {}
 
   '@aws-cdk/cloudformation-diff@2.182.0(@aws-sdk/client-cloudformation@3.699.0(aws-crt@1.27.1))':
     dependencies:
@@ -16144,7 +16154,7 @@ snapshots:
 
   '@docusaurus/react-loadable@5.5.2(react@17.0.2)':
     dependencies:
-      '@types/react': 17.0.87
+      '@types/react': 19.2.7
       prop-types: 15.8.1
       react: 17.0.2
 
@@ -18789,19 +18799,19 @@ snapshots:
   '@types/react-router-config@5.0.11':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 19.2.7
       '@types/react-router': 5.1.20
 
   '@types/react-router-dom@5.3.3':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 19.2.7
       '@types/react-router': 5.1.20
 
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 19.2.7
 
   '@types/react@17.0.87':
     dependencies:
@@ -19360,11 +19370,11 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  aws-cdk-lib@2.201.0(constructs@10.3.0):
+  aws-cdk-lib@2.253.0(constructs@10.3.0):
     dependencies:
-      '@aws-cdk/asset-awscli-v1': 2.2.237
-      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
-      '@aws-cdk/cloud-assembly-schema': 44.5.0
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.1
+      '@aws-cdk/cloud-assembly-schema': 53.23.0
       constructs: 10.3.0
 
   aws-crt@1.27.1:
@@ -24523,7 +24533,7 @@ snapshots:
 
   solid-js@1.9.7:
     dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
       seroval: 1.3.2
       seroval-plugins: 1.3.2(seroval@1.3.2)
 


### PR DESCRIPTION
  - Upgraded aws-cdk-lib from 2.201.0 to 2.253.0 (required for AuroraPostgresEngineVersion.VER_17_7)
  - Added certificateRef getter to CertificateBase to satisfy breaking change in ICertificate interface introduced in newer CDK versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Certificate constructs now expose a reference accessor that returns a certificate identifier for direct use in infrastructure and deployments.

* **Chores**
  * Bumped AWS CDK runtime dependencies to a newer 2.x release.

* **Documentation**
  * Clarified packaging and release instructions in the contributing guide, including renaming the packaged tarball before creating a release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bluestone-Health/sst-v2/pull/11)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->